### PR TITLE
Fixed README issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,10 +373,10 @@ Next, we will prepare the backup files. To do so, you must run **prepare-mysql.s
 
 If for any reason you don't want to restore some of the changes, now is your last chance to remove those incremental backup directories from the restore directory (the incremental backup files will still be available in the parent directory). Any remaining incremental- directories within the current directory will be applied to the full- backup directory.
 
-When you are ready, call the **prepare-mysql.sh** script:
+When you are ready, call the **prepare-mysql.sh** script (replacing your full path to the restore directory):
 
 ```
-prepare-mysql.sh ./restore
+sudo -u backup prepare-mysql.sh /var/backup/mysql/2021-07-23/restore
 
     Backup looks to be fully prepared.  Please check the "prepare-progress.log" file
     to verify before continuing.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains a few scripts for automating backups with mariabackup. 
 
 Please check and follow the instructions below. Original instructions are taken from <a href="https://www.digitalocean.com/community/tutorials/how-to-configure-mysql-backups-with-percona-xtrabackup-on-ubuntu-16-04">here</a>.
 
+## Prerequisites
+- Install pigz
+    sudo apt install pigz
+
 ## Create a MySQL User with Appropriate Privileges
 
 The first thing we need to do is create a new MySQL user configured to handle backup tasks. We will only give this user the privileges it needs to copy the data safely while the system is running.

--- a/README.md
+++ b/README.md
@@ -463,26 +463,22 @@ The next time we need a clean copies of the backup directories, we can extract t
 
 Now that we've verified that the backup and restore process are working smoothly, we should set up a cron job to automatically take regular backups.
 
-We will create a small script within the **/etc/cron.hourly** directory to automatically run our backup script and log the results. The cron process will automatically run this every hour:
+We will create a small script within the backup user crons to automatically run our backup script and log the results. The cron process will automatically run this every 15 minutes:
 
 ```
-sudo nano /etc/cron.hourly/backup-mysql
+sudo crontab -u backup -e
 ```
 
 Inside, we will call the backup script with the systemd-cat utility so that the output will be available in the journal. We'll mark them with a backup-mysql identifier so we can easily filter the logs:
 
 ```
-#!/bin/bash
-sudo -u backup systemd-cat --identifier=backup-mysql /usr/local/bin/backup-mysql.sh
+*/15 * *   *   *     /usr/local/bin/backup-mysql.sh
 ```
 
 Save and close the file when you are finished. Make the script executable by typing:
 
-```
-sudo chmod +x /etc/cron.hourly/backup-mysql
-```
 
-The backup script will now run hourly. The script itself will take care of cleaning up backups older than three days ago.
+The backup script will now run every 15 minutes. The script itself will take care of cleaning up backups older than three days ago.
 
 We can test the cron script by running it manually:
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Now that MySQL and system backup users are available, we can begin to set up the
 
 Begin by creating a minimal MySQL configuration file that the backup script will use. This will contain the MySQL credentials for the MySQL user.
 
-Open a file at **/var/backup/mysql/.my.cnf** (where **/var/backup** is home of backup user) in your text editor:
+Open a file at **/var/backup/.my.cnf** (where **/var/backup** is home of backup user) in your text editor:
 
 ```
 sudo mkdir -p /var/backup

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ sudo mkdir -p /var/lib/backup-mysql/
 sudo mkdir -p /etc/backup-mysql/
 sudo mv /tmp/common.inc /etc/backup-mysql/
 sudo mv /tmp/config.inc /var/lib/backup-mysql/
+sudo chmod +x /var/lib/backup-mysql/config.inc
+sudo chmod +x /etc/backup-mysql/common.inc
 ```
 
 ## Using the Backup and Restore Scripts

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ On Ubuntu 16.04 / Debian 8, a backup user and corresponding backup group is alre
 ```
 $ grep backup /etc/passwd /etc/group
 
-/etc/passwd:backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+/etc/passwd:backup:x:34:34:backup:/var/backup:/usr/sbin/nologin
 /etc/group:backup:x:34:
 
 ```
@@ -120,10 +120,10 @@ Now that MySQL and system backup users are available, we can begin to set up the
 
 Begin by creating a minimal MySQL configuration file that the backup script will use. This will contain the MySQL credentials for the MySQL user.
 
-Open a file at **/var/backups/mysql/.my.cnf** (where **/var/backups** is home of backup user) in your text editor:
+Open a file at **/var/backup/mysql/.my.cnf** (where **/var/backup** is home of backup user) in your text editor:
 
 ```
-$ sudo nano /var/backups/.my.cnf
+$ sudo nano /var/backup/.my.cnf
 ```
 
 Inside, start a ```[client]``` section and set the MySQL backup user and password user you defined within MySQL:
@@ -139,24 +139,24 @@ Save and close the file when you are finished.
 Give ownership of the file to the backup user and then restrict the permissions so that no other users can access the file:
 
 ```
-$ sudo chown backup /var/backups/.my.cnf
-$ sudo chmod 600 /var/backups/.my.cnf
+$ sudo chown backup /var/backup/.my.cnf
+$ sudo chmod 600 /var/backup/.my.cnf
 ```
 
 The backup user will be able to access this file to get the proper credentials but other users will be restricted.
 
 ### Create a Backup Root Directory
 
-Next, create a directory for the backup content. We will use **/var/backups/mysql** as the base directory for our backups:
+Next, create a directory for the backup content. We will use **/var/backup/mysql** as the base directory for our backups:
 
 ```
-$ sudo mkdir -p /var/backups/mysql
+$ sudo mkdir -p /var/backup/mysql
 ```
 
-Next, assign ownership of the **/var/backups/mysql** directory to the backup user and group ownership to the mysql group:
+Next, assign ownership of the **/var/backup/mysql** directory to the backup user and group ownership to the mysql group:
 
 ```
-$ sudo chown backup:mysql /var/backups/mysql
+$ sudo chown backup:mysql /var/backup/mysql
 ```
 
 The ```backup``` user should now be able to write backup data to this location.

--- a/README.md
+++ b/README.md
@@ -328,9 +328,10 @@ The backup type is listed as "incremental" and instead of starting from LSN 0 li
 
 Next, let's extract the backup files to create backup directories. Due to space and security considerations, this should normally only be done when you are ready to restore the data.
 
-We can extract the backups by passing the .xbstream backup files to the **extract-mysql.sh** script. We can run from any user with access to backups:
+We can extract the backups by passing the .xbstream backup files to the **extract-mysql.sh** script. We can run from any user with access to backups. Based on current script configuration, you must execute this command from the directory of the backup (i.e. 2021-07-23):
 
 ```
+cd /var/backup/mysql/2021-07-23
 sudo -u backup extract-mysql.sh /var/backup/mysql/2021-07-23/*.xbstream.gz
 
 Extraction complete! Backup directories have been extracted to the "restore" directory.

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Be sure to inspect the scripts after downloading to make sure they were retrieve
 chmod +x /tmp/{backup,extract,prepare}-mysql.sh
 sudo mv /tmp/{backup,extract,prepare}-mysql.sh /usr/local/bin
 sudo mkdir -p /var/lib/backup-mysql/
-sudo mv /tmp/common.inc /etc/backup-mysql/
 sudo mkdir -p /etc/backup-mysql/
+sudo mv /tmp/common.inc /etc/backup-mysql/
 sudo mv /tmp/config.inc /var/lib/backup-mysql/
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Now that MySQL and system backup users are available, we can begin to set up the
 
 Begin by creating a minimal MySQL configuration file that the backup script will use. This will contain the MySQL credentials for the MySQL user.
 
-Open a file at **/var/backups/.my.cnf** (where **/var/backups** is home of backup user) in your text editor:
+Open a file at **/var/backups/mysql/.my.cnf** (where **/var/backups** is home of backup user) in your text editor:
 
 ```
 $ sudo nano /var/backups/.my.cnf

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Be sure to inspect the scripts after downloading to make sure they were retrieve
 chmod +x /tmp/{backup,extract,prepare}-mysql.sh
 sudo mv /tmp/{backup,extract,prepare}-mysql.sh /usr/local/bin
 sudo mkdir -p /var/lib/backup-mysql/
-sudo mv /tmp/common.inc /etc/backup-mysql
+sudo mv /tmp/common.inc /etc/backup-mysql/
 sudo mkdir -p /etc/backup-mysql/
 sudo mv /tmp/config.inc /var/lib/backup-mysql/
 ```

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ sudo systemctl start mariadb
 After restoring your data, it is important to go back and delete the restore directory. Future incremental backups cannot be applied to the full backup once it has been prepared, so we should remove it. Furthermore, the backup directories should not be left unencrypted on disk for security reasons:
 
 ```
-rm -rf ./restore
+sudo rm -rf ./restore
 ```
 
 The next time we need a clean copies of the backup directories, we can extract them again from the backup files.

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Next, let's extract the backup files to create backup directories. Due to space 
 We can extract the backups by passing the .xbstream backup files to the **extract-mysql.sh** script. We can run from any user with access to backups:
 
 ```
-extract-mysql.sh /var/backup/mysql/2021-07-23/*.xbstream.gz
+sudo -u backup extract-mysql.sh /var/backup/mysql/2021-07-23/*.xbstream.gz
 
 Extraction complete! Backup directories have been extracted to the "restore" directory.
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Be sure to inspect the scripts after downloading to make sure they were retrieve
 chmod +x /tmp/{backup,extract,prepare}-mysql.sh
 sudo mv /tmp/{backup,extract,prepare}-mysql.sh /usr/local/bin
 sudo mkdir -p /var/lib/backup-mysql/
-sudo mv /tmp/common.inc /var/lib/backup-mysql/
+sudo mv /tmp/common.inc /etc/backup-mysql
 sudo mkdir -p /etc/backup-mysql/
-sudo mv /tmp/config.inc /etc/backup-mysql
+sudo mv /tmp/config.inc /var/lib/backup-mysql/
 ```
 
 ## Using the Backup and Restore Scripts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please check and follow the instructions below. Original instructions are taken 
 
 ## Prerequisites
 - Install pigz
-    sudo apt install pigz
+    ```sudo apt install pigz```
 
 ## Create a MySQL User with Appropriate Privileges
 

--- a/prepare-mysql.sh
+++ b/prepare-mysql.sh
@@ -83,6 +83,10 @@ main () {
             sudo chown -R mysql:mysql /var/lib/mysql
             sudo find /var/lib/mysql -type d -exec chmod 755 {} \;
             sudo systemctl start mariadb
+
+    After restoring your data, you must delete the restore directory or future incremental backups cannot be applied.
+
+            rm -rf ./restore
 EOF
     else
         error "It looks like something went wrong.  Check the \"${log_file}\" file for more information."

--- a/prepare-mysql.sh
+++ b/prepare-mysql.sh
@@ -76,7 +76,7 @@ main () {
     Then, recreate the data directory and  copy the backup files:
         
             sudo mkdir /var/lib/mysql
-            sudo mariabackup --copy-back --target-dir=${1}$(basename "${full_backup_dir}")
+            sudo mariabackup --copy-back --target-dir=${1}/$(basename "${full_backup_dir}")
         
     Afterward the files are copied, adjust the permissions and restart the service:
         

--- a/prepare-mysql.sh
+++ b/prepare-mysql.sh
@@ -81,7 +81,7 @@ main () {
     Afterward the files are copied, adjust the permissions and restart the service:
         
             sudo chown -R mysql:mysql /var/lib/mysql
-            sudo find /var/lib/mysql -type d -exec chmod 755 {} \\;
+            sudo find /var/lib/mysql -type d -exec chmod 755 {} \;
             sudo systemctl start mariadb
 EOF
     else

--- a/prepare-mysql.sh
+++ b/prepare-mysql.sh
@@ -86,7 +86,7 @@ main () {
 
     After restoring your data, you must delete the restore directory or future incremental backups cannot be applied.
 
-            rm -rf ./restore
+            sudo rm -rf ./restore
 EOF
     else
         error "It looks like something went wrong.  Check the \"${log_file}\" file for more information."


### PR DESCRIPTION
I fixed a number of readme typos that would prevent a user from following the instructions in detail without a complete understanding of the underlying scripts. This was due to the fact that several spots had minor typos. These mainly affected the directory structure.

For example, the copy commands for config.inc and common.inc were being sent to the wrong folders according to the scripts. 

I also removed the $ in front of commands. The reason for this is that when you have a multi line command, a user copies all commands at once (i.e. in the case of the several curl commands to retrieve the files). When a dollar sign is prefixed onto the command, that dollar sign ends up being inserted into their command line as they copy.

I also corrected the README to create the /var/backup/.my.cnf as this matches what the scripts were expecting. 

Thank you for all your work on these scripts and modifying them to work with Maria. You have done some great work and I really appreciate it.